### PR TITLE
Update patches for Siyuan 3.8

### DIFF
--- a/patches/siyuan/default-config.patch
+++ b/patches/siyuan/default-config.patch
@@ -1,22 +1,7 @@
-diff --git forkSrcPrefix/kernel/conf/appearance.go forkDstPrefix/kernel/conf/appearance.go
-index c3de55fa30ddf06238dad328c58af8221224d466..d48274f04afcc69848408a173920aa7634698e8c 100644
---- forkSrcPrefix/kernel/conf/appearance.go
-+++ forkDstPrefix/kernel/conf/appearance.go
-@@ -48,8 +48,8 @@ func NewAppearance() *Appearance {
- 		Icon:                "litheness",
- 		CodeBlockThemeLight: "github",
- 		CodeBlockThemeDark:  "base16/dracula",
--		Lang:                "en",
--		CloseButtonBehavior: 0,
-+		Lang:                "zh_CN",
-+		CloseButtonBehavior: 1,
- 		HideToolbar:         true,
- 		HideStatusBar:       false,
- 		StatusBar:           &util.StatusBar{},
-diff --git forkSrcPrefix/kernel/conf/account.go forkDstPrefix/kernel/conf/account.go
-index 5e3b51fb8f9d2944a2cacef66cdc3bc9bd365c5a..d4f4e00dea010730b557f7c122b624fb015b1021 100644
---- forkSrcPrefix/kernel/conf/account.go
-+++ forkDstPrefix/kernel/conf/account.go
+diff --git a/kernel/conf/account.go b/kernel/conf/account.go
+index c4590e22e..133208f71 100644
+--- a/kernel/conf/account.go
++++ b/kernel/conf/account.go
 @@ -23,7 +23,7 @@ type Account struct {
  
  func NewAccount() *Account {
@@ -27,11 +12,26 @@ index 5e3b51fb8f9d2944a2cacef66cdc3bc9bd365c5a..d4f4e00dea010730b557f7c122b624fb
 +		DisplayVIP:   false,
  	}
  }
-diff --git forkSrcPrefix/kernel/conf/sync.go forkDstPrefix/kernel/conf/sync.go
-index 1f23e9642ca641c0c73f9628f3c6e7695ea63cbb..7e40b4375a4a4543858b4b395aabd5c3cb5536ac 100644
---- forkSrcPrefix/kernel/conf/sync.go
-+++ forkDstPrefix/kernel/conf/sync.go
-@@ -37,8 +37,8 @@ func NewSync() *Sync {
+diff --git a/kernel/conf/appearance.go b/kernel/conf/appearance.go
+index 908de478f..c403c1587 100644
+--- a/kernel/conf/appearance.go
++++ b/kernel/conf/appearance.go
+@@ -50,8 +50,8 @@ func NewAppearance() *Appearance {
+ 		Icon:                "litheness",
+ 		CodeBlockThemeLight: "github",
+ 		CodeBlockThemeDark:  "base16/dracula",
+-		Lang:                "en",
+-		CloseButtonBehavior: 0,
++		Lang:                "zh_CN",
++		CloseButtonBehavior: 1,
+ 		HideToolbar:         true,
+ 		HideStatusBar:       false,
+ 		StatusBar:           &util.StatusBar{},
+diff --git a/kernel/conf/sync.go b/kernel/conf/sync.go
+index b076c5e7e..662b300d4 100644
+--- a/kernel/conf/sync.go
++++ b/kernel/conf/sync.go
+@@ -38,8 +38,8 @@ func NewSync() *Sync {
  		Enabled:             false,
  		Perception:          false,
  		Mode:                1,
@@ -40,5 +40,5 @@ index 1f23e9642ca641c0c73f9628f3c6e7695ea63cbb..7e40b4375a4a4543858b4b395aabd5c3
 +		GenerateConflictDoc: true,
 +		Provider:            ProviderS3,
  		Interval:            30,
+ 		LAN:                 &LANSync{MaxConcurrentReqs: 16},
  	}
- }

--- a/patches/siyuan/disable-update.patch
+++ b/patches/siyuan/disable-update.patch
@@ -1,51 +1,8 @@
-diff --git forkSrcPrefix/kernel/model/updater.go forkDstPrefix/kernel/model/updater.go
-index d1773fb3f1c6b6f61ba124aec081edd573996943..cbc13a8d69341fb40254b1665653cd10531cffa3 100644
---- forkSrcPrefix/kernel/model/updater.go
-+++ forkDstPrefix/kernel/model/updater.go
-@@ -312,6 +312,10 @@ func isVersionUpToDate(releaseVer string) bool {
- var skipInstallPkgPlatformCached = -1
- 
- func skipNewVerInstallPkg() bool {
-+	// Conf.System.DownloadInstallPkg(自动下载更新安装包) 强制赋值为false
-+	Conf.System.DownloadInstallPkg = false
-+	Conf.Save()
-+
- 	if skipInstallPkgPlatformCached == -1 {
- 		skipInstallPkgPlatformCached = 0
- 		if !gulu.OS.IsWindows() && !gulu.OS.IsDarwin() {
-diff --git forkSrcPrefix/kernel/model/mount.go forkDstPrefix/kernel/model/mount.go
-index b34f88cf23f43f4db768dbab940c05533959ad77..e3f8a9ee8d8519863a279479403735124e8a6542 100644
---- forkSrcPrefix/kernel/model/mount.go
-+++ forkDstPrefix/kernel/model/mount.go
-@@ -276,8 +276,8 @@ func Mount(boxID string) (alreadyMount bool, err error) {
- 		task.AppendAsyncTaskWithDelay(task.PushMsg, 3*time.Second, util.PushErrMsg, Conf.Language(244), 7000)
- 		go func() {
- 			// 每次打开帮助文档时自动检查版本更新并提醒 https://github.com/siyuan-note/siyuan/issues/5057
--			time.Sleep(time.Second * 10)
--			CheckUpdate(true)
-+			// time.Sleep(time.Second * 10)
-+			// CheckUpdate(true)
- 		}()
- 	}
- 
-diff --git forkSrcPrefix/kernel/conf/system.go forkDstPrefix/kernel/conf/system.go
-index 60ccf4f175b02f38c420c86cb33b27f04d6b6ea2..d8682bff5300e1877f521cda72289b9f2228e648 100644
---- forkSrcPrefix/kernel/conf/system.go
-+++ forkDstPrefix/kernel/conf/system.go
-@@ -57,7 +57,7 @@ func NewSystem() *System {
- 		Name:               util.GetDeviceName(),
- 		KernelVersion:      util.Ver,
- 		NetworkProxy:       &NetworkProxy{},
--		DownloadInstallPkg: true,
-+		DownloadInstallPkg: false,
- 	}
- }
- 
-diff --git forkSrcPrefix/kernel/api/system.go forkDstPrefix/kernel/api/system.go
-index bb3aa788c4ee166bc5f8152955484c29ce95b669..a5a210465120418c81b526368aa9cc1b74b24b5c 100644
---- forkSrcPrefix/kernel/api/system.go
-+++ forkDstPrefix/kernel/api/system.go
-@@ -274,16 +274,17 @@ func addCustomEmoji(name string, items *[]map[string]any) {
+diff --git a/kernel/api/system.go b/kernel/api/system.go
+index 93f5876e9..31df9aaf2 100644
+--- a/kernel/api/system.go
++++ b/kernel/api/system.go
+@@ -412,16 +412,17 @@ func normalizeCustomEmojiPath(name, ext string) (string, error) {
  }
  
  func checkUpdate(c *gin.Context) {
@@ -71,3 +28,46 @@ index bb3aa788c4ee166bc5f8152955484c29ce95b669..a5a210465120418c81b526368aa9cc1b
  }
  
  func exportLog(c *gin.Context) {
+diff --git a/kernel/conf/system.go b/kernel/conf/system.go
+index 8bf0031d2..8fd9ba567 100644
+--- a/kernel/conf/system.go
++++ b/kernel/conf/system.go
+@@ -77,7 +77,7 @@ func NewSystem() *System {
+ 		Name:               util.GetDeviceName(),
+ 		KernelVersion:      util.Ver,
+ 		NetworkProxy:       &NetworkProxy{},
+-		DownloadInstallPkg: true,
++		DownloadInstallPkg: false,
+ 		UpdateChannel:      UpdateChannelStable,
+ 	}
+ }
+diff --git a/kernel/model/mount.go b/kernel/model/mount.go
+index dba3aff7d..9b491b9e4 100644
+--- a/kernel/model/mount.go
++++ b/kernel/model/mount.go
+@@ -440,8 +440,8 @@ func mountBox(boxID string) (alreadyMount bool, err error) {
+ 		task.AppendAsyncTaskWithDelay(task.PushMsg, 3*time.Second, util.PushErrMsg, Conf.Language(244), 7000)
+ 		go func() {
+ 			// 每次打开帮助文档时自动检查版本更新并提醒 https://github.com/siyuan-note/siyuan/issues/5057
+-			time.Sleep(time.Second * 10)
+-			CheckUpdate(true)
++			// time.Sleep(time.Second * 10)
++			// CheckUpdate(true)
+ 		}()
+ 	}
+ 
+diff --git a/kernel/model/updater.go b/kernel/model/updater.go
+index 8a39a626b..6db50b966 100644
+--- a/kernel/model/updater.go
++++ b/kernel/model/updater.go
+@@ -267,6 +267,10 @@ func isVersionUpToDate(releaseVer string) bool {
+ var skipInstallPkgPlatformCached = -1
+ 
+ func skipNewVerInstallPkg() bool {
++	// Conf.System.DownloadInstallPkg(自动下载更新安装包) 强制赋值为false
++	Conf.System.DownloadInstallPkg = false
++	Conf.Save()
++
+ 	if skipInstallPkgPlatformCached == -1 {
+ 		skipInstallPkgPlatformCached = 0
+ 		if !gulu.OS.IsWindows() && !gulu.OS.IsDarwin() {


### PR DESCRIPTION
Update the existing Siyuan patches to apply cleanly to the new version.

### Changes

* `default-config.patch`

  * Updated the patch context for the newer `sync.go`, which now includes:
    `LAN: &LANSync{MaxConcurrentReqs: 16},`
  * No change to the intended patch behaviour.

* `disable-update.patch`

  * Updated the patch context/hunk locations.
  * The existing update-disabling changes remain unchanged.